### PR TITLE
Fixed a issue where a tagged query would fail when one or more events are deleted

### DIFF
--- a/src/Akka.Persistence.EventStore.Tests/Issues/Issue44_Problem_querying_deleted_events.cs
+++ b/src/Akka.Persistence.EventStore.Tests/Issues/Issue44_Problem_querying_deleted_events.cs
@@ -1,0 +1,73 @@
+using Akka.Actor;
+using Akka.Persistence.EventStore.Query;
+using Akka.Persistence.EventStore.Tests.Query;
+using Akka.Persistence.Query;
+using Akka.Streams;
+using Akka.Streams.TestKit;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Akka.Persistence.EventStore.Tests.Issues;
+
+[Collection("EventStoreDatabaseSpec")]
+public class Issue44_Problem_querying_deleted_events : Akka.TestKit.Xunit2.TestKit
+{
+    private readonly IReadJournal _readJournal;
+    private readonly ActorMaterializer _materializer;
+
+    public Issue44_Problem_querying_deleted_events(EventStoreContainer eventStoreContainer, ITestOutputHelper output)
+        : base(EventStoreConfiguration.Build(eventStoreContainer, Guid.NewGuid().ToString()),
+            output: output)
+    {
+        _readJournal = Sys.ReadJournalFor<EventStoreReadJournal>(EventStorePersistence.QueryConfigPath);
+        _materializer = Sys.Materializer();
+    }
+
+    [Fact]
+    public void ReadJournal_live_query_EventsByTag_should_ignore_deleted_events()
+    {
+        if (_readJournal is not IEventsByTagQuery readJournal)
+            throw IsTypeException.ForMismatchedType("IEventsByTagQuery", _readJournal.GetType().Name);
+
+        var testActor = Sys.ActorOf(Query.TestActor.Props("a"));
+
+        testActor.Tell("a black car");
+        ExpectMsg<string>("a black car-done");
+
+        testActor.Tell("a black cat");
+        ExpectMsg<string>("a black cat-done");
+
+        testActor.Tell("a black dog");
+        ExpectMsg<string>("a black dog-done");
+
+        testActor.Tell(new TestActor.DeleteCommand(2));
+        ExpectMsg<string>("2-deleted");
+        
+        ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+
+        var probe = readJournal.EventsByTag("black", Offset.NoOffset())
+            .RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
+        
+        probe.Request(5L);
+        
+        ExpectEnvelope(probe, "a", 3L, "a black dog");
+        
+        probe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        probe.Cancel();
+    }
+
+    private static void ExpectEnvelope(TestSubscriber.Probe<EventEnvelope> probe,
+        string persistenceId,
+        long sequenceNr,
+        string @event)
+    {
+        var eventEnvelope = probe.ExpectNext((Predicate<EventEnvelope>)(_ => true));
+        
+        eventEnvelope.PersistenceId.Should().Be(persistenceId);
+        
+        eventEnvelope.SequenceNr.Should().Be(sequenceNr);
+        eventEnvelope.Event.Should().Be(@event);
+    }
+}

--- a/src/Akka.Persistence.EventStore/Serialization/DefaultMessageAdapter.cs
+++ b/src/Akka.Persistence.EventStore/Serialization/DefaultMessageAdapter.cs
@@ -139,6 +139,9 @@ public class DefaultMessageAdapter(Akka.Serialization.Serialization serializatio
     [PublicAPI]
     protected virtual async Task<IStoredEventMetadata?> GetEventMetadataFrom(ResolvedEvent evnt)
     {
+        if (evnt.Event == null)
+            return null;
+        
         var metadata = await DeSerialize(evnt.Event.Metadata, typeof(StoredEventMetadata));
         
         return metadata as IStoredEventMetadata;

--- a/src/Akka.Persistence.EventStore/Streams/EventStoreStreamSourceExtensions.cs
+++ b/src/Akka.Persistence.EventStore/Streams/EventStoreStreamSourceExtensions.cs
@@ -46,9 +46,12 @@ public static class EventStoreStreamSourceExtensions
         Func<ResolvedEvent, Task<TResult?>> deserializer)
     {
         return source
-            .SelectAsync(1, async evnt => await deserializer(evnt))
-            .Where(x => x != null)
-            .Select(x => x!);
+            .SelectAsync(1, async evnt => new
+            {
+                Deserialized = await deserializer(evnt)
+            })
+            .Where(x => x.Deserialized != null)
+            .Select(x => x.Deserialized!);
     }
     
     public static Source<TResult, TMat> DeSerializeWith<TResult, TMat>(


### PR DESCRIPTION
Fixes #44

## Changes

Fixed a issue where a tagged query would fail when one or more events are deleted
