### PR TITLE
Bump Akka.NET to 1.5.59

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,17 +1,11 @@
 <Project>
   <PropertyGroup>
-    <Copyright>Copyright © 2013-2024 Akka.NET Project</Copyright>
+    <Copyright>Copyright © 2013-2025 Akka.NET Project</Copyright>
     <NoWarn>$(NoWarn);CS1591;NU1701;CA1707;</NoWarn>
-    <VersionPrefix>1.5.40</VersionPrefix>
+    <VersionPrefix>1.5.59</VersionPrefix>
     <Authors>Akka.NET Team</Authors>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.EventStore</PackageProjectUrl>
-    <PackageReleaseNotes>Serialization changes to match 1.4 API
-Upgrade to Akka 1.4 dependency
-Upgrade to EventStore 5 dependency
-netstandard2 and netfx452 (from netstandard1.6 and netfx45)
-
-**Breaking Changes**
-EventAdapter interface change (see README)</PackageReleaseNotes>
+    <PackageReleaseNotes>* [Bumped Akka to version 1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>logo.png</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.46</AkkaVersion>
-    <AkkaHostingVersion>1.5.46</AkkaHostingVersion>
+    <AkkaVersion>1.5.59</AkkaVersion>
+    <AkkaHostingVersion>1.5.59</AkkaHostingVersion>
     <EventStoreVersion>23.3.9</EventStoreVersion>
     <XunitVersion>2.9.3</XunitVersion>
     <TestSdkVersion>17.14.1</TestSdkVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 1.5.59 January 26th, 2025 ####
+* [Bumped Akka to version 1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
+
 #### 1.5.46 August 4th, 2025 ####
 * [Bumped Akka to version 1.5.46](https://github.com/akkadotnet/akka.net/releases/tag/1.5.46)
 * [Added option to disable revision check](https://github.com/akkadotnet/Akka.Persistence.EventStore/pull/68)


### PR DESCRIPTION
## Summary
- Upgrade Akka.NET to 1.5.59

## Changes
- [Akka.NET 1.5.59 Release Notes](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)