### PR TITLE
Fix xUnit1051 warnings: use async Expect* overloads with TestContext.Current.CancellationToken

### DIFF
--- a/src/Akka.Persistence.EventStore.Hosting.Tests/EventStoreEndToEndSpec.cs
+++ b/src/Akka.Persistence.EventStore.Hosting.Tests/EventStoreEndToEndSpec.cs
@@ -40,15 +40,15 @@ public class EventStoreEndToEndSpec(ITestOutputHelper output, EventStoreContaine
         var timeout = TimeSpan.FromSeconds(3);
 
         // arrange
-        var myPersistentActor = await ActorRegistry.GetAsync<MyPersistenceActor>();
+        var myPersistentActor = await ActorRegistry.GetAsync<MyPersistenceActor>(TestContext.Current.CancellationToken);
 
         // act
         myPersistentActor.Tell(1, senderProbe);
-        senderProbe.ExpectMsg<string>(Ack);
+        await senderProbe.ExpectMsgAsync<string>(Ack, cancellationToken: TestContext.Current.CancellationToken);
         myPersistentActor.Tell(2, senderProbe);
-        senderProbe.ExpectMsg<string>(Ack);
-        senderProbe.ExpectMsg<string>(SnapshotAck);
-        var snapshot = await myPersistentActor.Ask<int[]>(GetAll, timeout);
+        await senderProbe.ExpectMsgAsync<string>(Ack, cancellationToken: TestContext.Current.CancellationToken);
+        await senderProbe.ExpectMsgAsync<string>(SnapshotAck, cancellationToken: TestContext.Current.CancellationToken);
+        var snapshot = await myPersistentActor.Ask<int[]>(GetAll, timeout, TestContext.Current.CancellationToken);
 
         // assert
         Assert.Equivalent(new[] { 1, 2 }, snapshot, strict: true);
@@ -57,7 +57,7 @@ public class EventStoreEndToEndSpec(ITestOutputHelper output, EventStoreContaine
         await myPersistentActor.GracefulStop(timeout);
         var myPersistentActor2 = Sys.ActorOf(Props.Create(() => new MyPersistenceActor(PId)));
 
-        var snapshot2 = await myPersistentActor2.Ask<int[]>(GetAll, timeout);
+        var snapshot2 = await myPersistentActor2.Ask<int[]>(GetAll, timeout, TestContext.Current.CancellationToken);
         Assert.Equivalent(new[] { 1, 2 }, snapshot2, strict: true);
 
         // validate configs
@@ -70,8 +70,8 @@ public class EventStoreEndToEndSpec(ITestOutputHelper output, EventStoreContaine
         var source = readJournal.AllEvents(Offset.NoOffset());
         var probe = source.RunWith(this.SinkProbe<EventEnvelope>(), Sys.Materializer());
         probe.Request(2);
-        probe.ExpectNext<EventEnvelope>(p => p.PersistenceId == PId && p.SequenceNr == 1L && p.Event.Equals(1));
-        probe.ExpectNext<EventEnvelope>(p => p.PersistenceId == PId && p.SequenceNr == 2L && p.Event.Equals(2));
+        await probe.ExpectNextAsync<EventEnvelope>(p => p.PersistenceId == PId && p.SequenceNr == 1L && p.Event.Equals(1), TestContext.Current.CancellationToken);
+        await probe.ExpectNextAsync<EventEnvelope>(p => p.PersistenceId == PId && p.SequenceNr == 2L && p.Event.Equals(2), TestContext.Current.CancellationToken);
         await probe.CancelAsync();
     }
 

--- a/src/Akka.Persistence.EventStore.Tests/Issues/Issue44_Problem_querying_deleted_events.cs
+++ b/src/Akka.Persistence.EventStore.Tests/Issues/Issue44_Problem_querying_deleted_events.cs
@@ -24,7 +24,7 @@ public class Issue44_Problem_querying_deleted_events : Akka.TestKit.Xunit.TestKi
     }
 
     [Fact]
-    public void ReadJournal_live_query_EventsByTag_should_ignore_deleted_events()
+    public async Task ReadJournal_live_query_EventsByTag_should_ignore_deleted_events()
     {
         if (_readJournal is not IEventsByTagQuery readJournal)
             throw IsTypeException.ForMismatchedType("IEventsByTagQuery", _readJournal.GetType().Name);
@@ -32,36 +32,36 @@ public class Issue44_Problem_querying_deleted_events : Akka.TestKit.Xunit.TestKi
         var testActor = Sys.ActorOf(Query.TestActor.Props("a"));
 
         testActor.Tell("a black car");
-        ExpectMsg<string>("a black car-done");
+        await ExpectMsgAsync<string>("a black car-done", cancellationToken: TestContext.Current.CancellationToken);
 
         testActor.Tell("a black cat");
-        ExpectMsg<string>("a black cat-done");
+        await ExpectMsgAsync<string>("a black cat-done", cancellationToken: TestContext.Current.CancellationToken);
 
         testActor.Tell("a black dog");
-        ExpectMsg<string>("a black dog-done");
+        await ExpectMsgAsync<string>("a black dog-done", cancellationToken: TestContext.Current.CancellationToken);
 
         testActor.Tell(new TestActor.DeleteCommand(2));
-        ExpectMsg<string>("2-deleted");
-        
-        ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+        await ExpectMsgAsync<string>("2-deleted", cancellationToken: TestContext.Current.CancellationToken);
+
+        await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
 
         var probe = readJournal.EventsByTag("black", Offset.NoOffset())
             .RunWith(this.SinkProbe<EventEnvelope>(), _materializer);
         
         probe.Request(5L);
         
-        ExpectEnvelope(probe, "a", 3L, "a black dog");
-        
-        probe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        await ExpectEnvelopeAsync(probe, "a", 3L, "a black dog");
+
+        await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
         probe.Cancel();
     }
 
-    private static void ExpectEnvelope(TestSubscriber.Probe<EventEnvelope> probe,
+    private static async Task ExpectEnvelopeAsync(TestSubscriber.Probe<EventEnvelope> probe,
         string persistenceId,
         long sequenceNr,
         string @event)
     {
-        var eventEnvelope = probe.ExpectNext((Predicate<EventEnvelope>)(_ => true));
+        var eventEnvelope = await probe.ExpectNextAsync<EventEnvelope>(_ => true, TestContext.Current.CancellationToken);
         
         Assert.Equal(persistenceId, eventEnvelope.PersistenceId);
         

--- a/src/Akka.Persistence.EventStore.Tests/Issues/Issue81_Problem_with_concurrent_ack_and_nack.cs
+++ b/src/Akka.Persistence.EventStore.Tests/Issues/Issue81_Problem_with_concurrent_ack_and_nack.cs
@@ -86,7 +86,7 @@ public class Issue81_Problem_with_concurrent_ack_and_nack : Akka.TestKit.Xunit.T
             .Take(numberOfEvents)
             .RunWith(Sink.Ignore<PersistentSubscriptionEvent>(), Sys.Materializer());
 
-        await task.WaitAsync(TimeSpan.FromSeconds(30));
+        await task.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
 
         Assert.Empty(errors);
         Assert.Equal(numberOfEvents, ackedCount);
@@ -143,7 +143,7 @@ public class Issue81_Problem_with_concurrent_ack_and_nack : Akka.TestKit.Xunit.T
             .Take(numberOfEvents)
             .RunWith(Sink.Ignore<PersistentSubscriptionEvent>(), Sys.Materializer());
 
-        await task.WaitAsync(TimeSpan.FromSeconds(30));
+        await task.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
 
         Assert.Empty(errors);
         Assert.Equal(numberOfEvents, nackedCount);

--- a/src/Akka.Persistence.EventStore.Tests/PersistentSubscriptionSpec.cs
+++ b/src/Akka.Persistence.EventStore.Tests/PersistentSubscriptionSpec.cs
@@ -32,19 +32,19 @@ public class PersistentSubscriptionSpec : Akka.TestKit.Xunit.TestKit
 
         probe.Request(5);
 
-        var firstMessage = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-1");
+        var firstMessage = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-1", TestContext.Current.CancellationToken);
 
         await firstMessage.Ack();
-        
-        var secondMessage = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-2");
+
+        var secondMessage = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-2", TestContext.Current.CancellationToken);
 
         await secondMessage.Ack();
 
-        probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
-        
+        await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
+
         probe.Cancel();
     }
-    
+
     [Fact]
     public async Task ReadJournal_PersistentSubscription_should_see_new_events()
     {
@@ -54,26 +54,27 @@ public class PersistentSubscriptionSpec : Akka.TestKit.Xunit.TestKit
 
         probe.Request(5);
 
-        var firstMessage = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-1");
+        var firstMessage = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-1", TestContext.Current.CancellationToken);
 
         await firstMessage.Ack();
 
-        probe.ExpectNoMsg(TimeSpan.FromMilliseconds(200));
-        
+        await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200), TestContext.Current.CancellationToken);
+
         await _eventStoreClient.AppendToStreamAsync(
             streamName,
-            StreamState.Any, 
+            StreamState.Any,
             ImmutableList.Create(
                 new EventData(
                     Uuid.NewUuid(),
                     $"{streamName}-2",
-                    "{}"u8.ToArray())));
-        
-        var secondMessage = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-2");
+                    "{}"u8.ToArray())),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var secondMessage = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-2", TestContext.Current.CancellationToken);
 
         await secondMessage.Ack();
-        
-        probe.ExpectNoMsg(TimeSpan.FromMilliseconds(200));
+
+        await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200), TestContext.Current.CancellationToken);
 
         probe.Cancel();
     }
@@ -91,12 +92,12 @@ public class PersistentSubscriptionSpec : Akka.TestKit.Xunit.TestKit
         {
             var itemId = i;
             
-            var msg = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-{itemId}");
+            var msg = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-{itemId}", TestContext.Current.CancellationToken);
 
             await msg.Ack();
         }
-        
-        probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+
+        await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
         
         probe.Cancel();
     }
@@ -113,30 +114,31 @@ public class PersistentSubscriptionSpec : Akka.TestKit.Xunit.TestKit
 
         probe.Request(5);
 
-        var firstMessage = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-1");
+        var firstMessage = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-1", TestContext.Current.CancellationToken);
 
         await firstMessage.Ack();
 
-        probe.ExpectNoMsg(TimeSpan.FromMilliseconds(200));
+        await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200), TestContext.Current.CancellationToken);
 
-        await _subscriptionClient.RestartSubsystemAsync();
+        await _subscriptionClient.RestartSubsystemAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        await Task.Delay(TimeSpan.FromSeconds(10));
-        
+        await Task.Delay(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
         await _eventStoreClient.AppendToStreamAsync(
             streamName,
-            StreamState.Any, 
+            StreamState.Any,
             ImmutableList.Create(
                 new EventData(
                     Uuid.NewUuid(),
                     $"{streamName}-2",
-                    "{}"u8.ToArray())));
-        
-        var secondMessage = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-2");
+                    "{}"u8.ToArray())),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var secondMessage = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-2", TestContext.Current.CancellationToken);
 
         await secondMessage.Ack();
-        
-        probe.ExpectNoMsg(TimeSpan.FromMilliseconds(200));
+
+        await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200), TestContext.Current.CancellationToken);
 
         probe.Cancel();
     }
@@ -150,15 +152,15 @@ public class PersistentSubscriptionSpec : Akka.TestKit.Xunit.TestKit
 
         probe.Request(5);
 
-        var firstMessage = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-1");
+        var firstMessage = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-1", TestContext.Current.CancellationToken);
 
         await firstMessage.Ack();
 
-        probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+        await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
 
-        await _subscriptionClient.RestartSubsystemAsync();
+        await _subscriptionClient.RestartSubsystemAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        await probe.ExpectErrorAsync();
+        await probe.ExpectErrorAsync(TestContext.Current.CancellationToken);
     }
     
     [Fact]
@@ -170,21 +172,21 @@ public class PersistentSubscriptionSpec : Akka.TestKit.Xunit.TestKit
 
         probe.Request(5);
 
-        var firstMessage = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-1");
+        var firstMessage = await probe.ExpectNextAsync<PersistentSubscriptionEvent>(x => x.Event.Event.EventType == $"{streamName}-1", TestContext.Current.CancellationToken);
 
         await firstMessage.Ack();
 
-        probe.ExpectNoMsg(TimeSpan.FromMilliseconds(300));
-        
-        var subscriptionBeforeCancel = await _subscriptionClient.GetInfoToStreamAsync(streamName, streamName);
+        await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300), TestContext.Current.CancellationToken);
+
+        var subscriptionBeforeCancel = await _subscriptionClient.GetInfoToStreamAsync(streamName, streamName, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Single(subscriptionBeforeCancel.Connections);
 
         probe.Cancel();
-        
-        await Task.Delay(TimeSpan.FromMilliseconds(300));
 
-        var subscriptionAfterCancel = await _subscriptionClient.GetInfoToStreamAsync(streamName, streamName);
+        await Task.Delay(TimeSpan.FromMilliseconds(300), TestContext.Current.CancellationToken);
+
+        var subscriptionAfterCancel = await _subscriptionClient.GetInfoToStreamAsync(streamName, streamName, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Empty(subscriptionAfterCancel.Connections);
     }
@@ -197,18 +199,20 @@ public class PersistentSubscriptionSpec : Akka.TestKit.Xunit.TestKit
         await _subscriptionClient.CreateToStreamAsync(
             streamName,
             streamName,
-            new PersistentSubscriptionSettings());
+            new PersistentSubscriptionSettings(),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         for (var i = 1; i <= numberOfEvents; i++)
         {
             await _eventStoreClient.AppendToStreamAsync(
                 streamName,
-                StreamState.Any, 
+                StreamState.Any,
                 ImmutableList.Create(
                     new EventData(
                         Uuid.NewUuid(),
                         $"{streamName}-{i}",
-                        "{}"u8.ToArray())));
+                        "{}"u8.ToArray())),
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         var stream = EventStoreSource

--- a/src/Akka.Persistence.EventStore.Tests/Query/EventStoreCurrentEventsByTagSpec.cs
+++ b/src/Akka.Persistence.EventStore.Tests/Query/EventStoreCurrentEventsByTagSpec.cs
@@ -30,7 +30,9 @@ public class EventStoreCurrentEventsByTagSpec : CurrentEventsByTagSpec
         foreach (var _ in Enumerable.Range(1, 150))
         {
             a.Tell("a green apple");
-            ExpectMsg("a green apple-done");
+            // NOTE: this is a synchronous `override void` TCK method, so the async Expect*Async
+            // variants cannot be awaited here; pass the token to the synchronous overload instead.
+            ExpectMsg("a green apple-done", cancellationToken: TestContext.Current.CancellationToken);
         }
         
         Thread.Sleep(TimeSpan.FromMilliseconds(300));
@@ -43,8 +45,8 @@ public class EventStoreCurrentEventsByTagSpec : CurrentEventsByTagSpec
             ExpectEnvelope(probe, "a", i, "a green apple", "green");
         }
 
-        probe.ExpectComplete();
-        probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
+        probe.ExpectComplete(TestContext.Current.CancellationToken);
+        probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
     }
     
     [Fact]
@@ -55,8 +57,8 @@ public class EventStoreCurrentEventsByTagSpec : CurrentEventsByTagSpec
 
         var actor = Sys.ActorOf(Query.TestActor.Props("a"));
         actor.Tell("a green apple");
-        ExpectMsg("a green apple-done");
-        
+        await ExpectMsgAsync<string>("a green apple-done", cancellationToken: TestContext.Current.CancellationToken);
+
         const string tag = "green";
 
         var round1 = await journal.CurrentEventsByTag(tag, Offset.NoOffset())
@@ -72,9 +74,9 @@ public class EventStoreCurrentEventsByTagSpec : CurrentEventsByTagSpec
         Assert.Empty(round2);
 
         actor.Tell("a green banana");
-        ExpectMsg("a green banana-done");
+        await ExpectMsgAsync<string>("a green banana-done", cancellationToken: TestContext.Current.CancellationToken);
 
-        await Task.Delay(TimeSpan.FromMilliseconds(300));
+        await Task.Delay(TimeSpan.FromMilliseconds(300), TestContext.Current.CancellationToken);
         
         var round3 = await journal.CurrentEventsByTag(tag, item1Offset)
             .RunWith(Sink.Seq<EventEnvelope>(), Sys.Materializer());


### PR DESCRIPTION
Follow-up to #85. The xUnit v3 migration left ~48 `xUnit1051` analyzer warnings: *"Calls to methods which accept CancellationToken should use `TestContext.Current.CancellationToken` to allow test cancellation to be more responsive."*

## Approach

Rather than bolt the token onto the **blocking** synchronous `Expect*` helpers (which just do `.GetAwaiter().GetResult()` internally), this switches to the **`Task`-returning async variants** and awaits them:

- `ExpectMsg` → `await ExpectMsgAsync(..., cancellationToken: TestContext.Current.CancellationToken)`
- `ExpectNoMsg` → `await ExpectNoMsgAsync(...)`
- `ExpectNext` → `await ExpectNextAsync(...)`
- `ExpectComplete` / `ExpectError` → async variants where awaitable
- `Ask`, `Task.Delay`, `Task.WaitAsync`, EventStore client calls, and `ActorRegistry.GetAsync` get `TestContext.Current.CancellationToken` threaded through

`Issue44`'s test method and its `ExpectEnvelope` helper were promoted to `async Task` so the async variants can be awaited.

## One documented exception

`EventStoreCurrentEventsByTagSpec.ReadJournal_query_CurrentEventsByTag_should_see_all_150_events` is a synchronous `override void` TCK method — its signature can't change to `async Task`, so the token is passed to the **synchronous** `Expect*` overloads there (with an explanatory code comment). Open to suppressing instead if preferred.

## Verification

- Build: **0 errors, 0 `xUnit1051`** (remaining warnings are pre-existing `CS0618`/`CS863x`/`CS7022`, untouched by this PR).
- Full suite passes against EventStore `23.10.0`: **Tests 138 passed / 3 skipped, Hosting.Tests 7 passed**.