### PR TITLE
Add Offset.FromEnd support to EventStore queries

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### Unreleased ####
+* Added `Offset.FromEnd` support to current and live events-by-tag and all-events queries.
+
 #### 1.5.70 July 6th, 2026 ####
 * [Bumped Akka to version 1.5.70](https://github.com/akkadotnet/Akka.Persistence.EventStore/pull/88)
 * [Fixed an issue with concurrent writes for persistent subscriptions](https://github.com/akkadotnet/Akka.Persistence.EventStore/pull/83)

--- a/src/Akka.Persistence.EventStore.Tests/Query/EventStoreFromEndOffsetSpec.cs
+++ b/src/Akka.Persistence.EventStore.Tests/Query/EventStoreFromEndOffsetSpec.cs
@@ -1,0 +1,233 @@
+using Akka.Actor;
+using Akka.Persistence.EventStore.Query;
+using Akka.Persistence.Query;
+using Akka.Persistence.TCK.Query;
+using Akka.Streams.Dsl;
+using Akka.Streams.TestKit;
+using Xunit;
+
+namespace Akka.Persistence.EventStore.Tests.Query;
+
+[Collection(nameof(EventStoreTestsDatabaseCollection))]
+public class EventStoreFromEndOffsetSpec : FromEndOffsetSpec
+{
+    public EventStoreFromEndOffsetSpec(EventStoreContainer eventStoreContainer, ITestOutputHelper output) :
+        base(EventStoreConfiguration.Build(eventStoreContainer, Guid.NewGuid().ToString()),
+            nameof(EventStoreFromEndOffsetSpec),
+            output)
+    {
+        ReadJournal = Sys.ReadJournalFor<EventStoreReadJournal>(EventStorePersistence.QueryConfigPath);
+    }
+
+    [Fact]
+    public async Task ReadJournal_query_FromEnd_should_resolve_when_the_source_is_materialized()
+    {
+        var queries = Assert.IsAssignableFrom<ICurrentAllEventsQuery>(ReadJournal);
+        var source = queries.CurrentAllEvents(Offset.FromEnd(2));
+        var actor = Sys.ActorOf(
+            global::Akka.Persistence.EventStore.Tests.Query.TestActor.Props("materialization-time"));
+
+        for (var sequenceNr = 1; sequenceNr <= 3; sequenceNr++)
+        {
+            var message = $"event-{sequenceNr}";
+            actor.Tell(message);
+            await ExpectMsgAsync($"{message}-done", cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        await AwaitConditionAsync(async () =>
+        {
+            var visible = await queries.CurrentAllEvents(Offset.NoOffset())
+                .RunWith(Sink.Seq<EventEnvelope>(), Materializer);
+            return visible.Count >= 3;
+        }, max: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
+
+        var events = await source.RunWith(Sink.Seq<EventEnvelope>(), Materializer);
+
+        Assert.Collection(
+            events,
+            envelope =>
+            {
+                Assert.Equal("materialization-time", envelope.PersistenceId);
+                Assert.Equal(2, envelope.SequenceNr);
+                Assert.IsType<Sequence>(envelope.Offset);
+            },
+            envelope =>
+            {
+                Assert.Equal("materialization-time", envelope.PersistenceId);
+                Assert.Equal(3, envelope.SequenceNr);
+                Assert.IsType<Sequence>(envelope.Offset);
+            });
+    }
+
+    [Fact]
+    public void ReadJournal_query_should_reject_unsupported_offset_types()
+    {
+        var unsupported = Offset.TimeBasedUuid(Guid.NewGuid());
+
+        Assert.Throws<ArgumentException>(
+            () => Assert.IsAssignableFrom<IEventsByTagQuery>(ReadJournal).EventsByTag("green", unsupported));
+        Assert.Throws<ArgumentException>(
+            () => Assert.IsAssignableFrom<ICurrentEventsByTagQuery>(ReadJournal)
+                .CurrentEventsByTag("green", unsupported));
+        Assert.Throws<ArgumentException>(
+            () => Assert.IsAssignableFrom<IAllEventsQuery>(ReadJournal).AllEvents(unsupported));
+        Assert.Throws<ArgumentException>(
+            () => Assert.IsAssignableFrom<ICurrentAllEventsQuery>(ReadJournal).CurrentAllEvents(unsupported));
+    }
+
+    [Fact]
+    public async Task ReadJournal_query_CurrentEventsByTag_with_FromEnd_should_count_only_visible_events()
+    {
+        await PersistDeadLinkFixtureAsync();
+        var queries = Assert.IsAssignableFrom<ICurrentEventsByTagQuery>(ReadJournal);
+
+        var events = await queries.CurrentEventsByTag("black", Offset.FromEnd(2))
+            .RunWith(Sink.Seq<EventEnvelope>(), Materializer);
+
+        AssertVisibleWindow(events);
+    }
+
+    [Fact]
+    public async Task ReadJournal_live_query_EventsByTag_with_FromEnd_should_count_only_visible_events_then_continue()
+    {
+        var (_, lastActor) = await PersistDeadLinkFixtureAsync();
+        var queries = Assert.IsAssignableFrom<IEventsByTagQuery>(ReadJournal);
+        var probe = queries.EventsByTag("black", Offset.FromEnd(2))
+            .RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
+        probe.Request(10);
+
+        await AssertNextEnvelopeAsync(probe, "visible-b", 2);
+        await AssertNextEnvelopeAsync(probe, "visible-c", 1);
+
+        await PersistAsync(lastActor, "new black event");
+        await AssertNextEnvelopeAsync(probe, "visible-c", 2);
+        probe.Cancel();
+    }
+
+    [Fact]
+    public async Task ReadJournal_query_CurrentAllEvents_with_FromEnd_should_count_only_visible_events()
+    {
+        await PersistDeadLinkFixtureAsync();
+        var queries = Assert.IsAssignableFrom<ICurrentAllEventsQuery>(ReadJournal);
+
+        var events = await queries.CurrentAllEvents(Offset.FromEnd(2))
+            .RunWith(Sink.Seq<EventEnvelope>(), Materializer);
+
+        AssertVisibleWindow(events);
+    }
+
+    [Fact]
+    public async Task ReadJournal_live_query_AllEvents_with_FromEnd_should_count_only_visible_events_then_continue()
+    {
+        var (_, lastActor) = await PersistDeadLinkFixtureAsync();
+        var queries = Assert.IsAssignableFrom<IAllEventsQuery>(ReadJournal);
+        var probe = queries.AllEvents(Offset.FromEnd(2))
+            .RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
+        probe.Request(10);
+
+        await AssertNextEnvelopeAsync(probe, "visible-b", 2);
+        await AssertNextEnvelopeAsync(probe, "visible-c", 1);
+
+        await PersistAsync(lastActor, "new untagged event");
+        await AssertNextEnvelopeAsync(probe, "visible-c", 2);
+        probe.Cancel();
+    }
+
+    private async Task<(IActorRef Visible, IActorRef Last)> PersistDeadLinkFixtureAsync()
+    {
+        var visible = Sys.ActorOf(
+            global::Akka.Persistence.EventStore.Tests.Query.TestActor.Props("visible-b"));
+        var deleted = Sys.ActorOf(
+            global::Akka.Persistence.EventStore.Tests.Query.TestActor.Props("deleted-a"));
+        var last = Sys.ActorOf(
+            global::Akka.Persistence.EventStore.Tests.Query.TestActor.Props("visible-c"));
+
+        await PersistAsync(visible, "first black event");
+        await PersistAsync(visible, "second black event");
+        await PersistAsync(deleted, "deleted black event");
+        await PersistAsync(last, "last black event");
+
+        var currentByTag = Assert.IsAssignableFrom<ICurrentEventsByTagQuery>(ReadJournal);
+        var currentAll = Assert.IsAssignableFrom<ICurrentAllEventsQuery>(ReadJournal);
+        await AwaitVisibleAsync(
+            () => currentByTag.CurrentEventsByTag("black", Offset.NoOffset()),
+            ("visible-b", 1),
+            ("visible-b", 2),
+            ("deleted-a", 1),
+            ("visible-c", 1));
+        await AwaitVisibleAsync(
+            () => currentAll.CurrentAllEvents(Offset.NoOffset()),
+            ("visible-b", 1),
+            ("visible-b", 2),
+            ("deleted-a", 1),
+            ("visible-c", 1));
+
+        deleted.Tell(new global::Akka.Persistence.EventStore.Tests.Query.TestActor.DeleteCommand(1));
+        await ExpectMsgAsync<string>("1-deleted", cancellationToken: TestContext.Current.CancellationToken);
+
+        await AwaitVisibleAsync(
+            () => currentByTag.CurrentEventsByTag("black", Offset.NoOffset()),
+            ("visible-b", 1),
+            ("visible-b", 2),
+            ("visible-c", 1));
+        await AwaitVisibleAsync(
+            () => currentAll.CurrentAllEvents(Offset.NoOffset()),
+            ("visible-b", 1),
+            ("visible-b", 2),
+            ("visible-c", 1));
+
+        return (visible, last);
+    }
+
+    private async Task PersistAsync(IActorRef actor, string message)
+    {
+        actor.Tell(message);
+        await ExpectMsgAsync<string>(
+            $"{message}-done",
+            cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    private async Task AwaitVisibleAsync(
+        Func<Source<EventEnvelope, NotUsed>> query,
+        params (string PersistenceId, long SequenceNr)[] expected)
+    {
+        await AwaitConditionAsync(async () =>
+        {
+            var events = await query().RunWith(Sink.Seq<EventEnvelope>(), Materializer);
+            return events
+                .Select(envelope => (envelope.PersistenceId, envelope.SequenceNr))
+                .SequenceEqual(expected);
+        }, max: TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    private static void AssertVisibleWindow(IReadOnlyCollection<EventEnvelope> events)
+    {
+        Assert.Collection(
+            events,
+            envelope =>
+            {
+                Assert.Equal("visible-b", envelope.PersistenceId);
+                Assert.Equal(2, envelope.SequenceNr);
+                Assert.IsType<Sequence>(envelope.Offset);
+            },
+            envelope =>
+            {
+                Assert.Equal("visible-c", envelope.PersistenceId);
+                Assert.Equal(1, envelope.SequenceNr);
+                Assert.IsType<Sequence>(envelope.Offset);
+            });
+    }
+
+    private static async Task AssertNextEnvelopeAsync(
+        TestSubscriber.Probe<EventEnvelope> probe,
+        string persistenceId,
+        long sequenceNr)
+    {
+        var envelope = await probe.ExpectNextAsync<EventEnvelope>(
+            _ => true,
+            TestContext.Current.CancellationToken);
+        Assert.Equal(persistenceId, envelope.PersistenceId);
+        Assert.Equal(sequenceNr, envelope.SequenceNr);
+        Assert.IsType<Sequence>(envelope.Offset);
+    }
+}

--- a/src/Akka.Persistence.EventStore.Tests/Query/TestActor.cs
+++ b/src/Akka.Persistence.EventStore.Tests/Query/TestActor.cs
@@ -4,6 +4,8 @@ namespace Akka.Persistence.EventStore.Tests.Query;
 
 internal class TestActor : UntypedPersistentActor
 {
+    private IActorRef? _deleteRequester;
+
     public static Props Props(string persistenceId) => Actor.Props.Create(() => new TestActor(persistenceId));
 
     public sealed class DeleteCommand
@@ -32,8 +34,16 @@ internal class TestActor : UntypedPersistentActor
         switch (message)
         {
             case DeleteCommand delete:
+                _deleteRequester = Sender;
                 DeleteMessages(delete.ToSequenceNr);
-                Sender.Tell($"{delete.ToSequenceNr}-deleted");
+                break;
+            case DeleteMessagesSuccess success:
+                _deleteRequester?.Tell($"{success.ToSequenceNr}-deleted");
+                _deleteRequester = null;
+                break;
+            case DeleteMessagesFailure failure:
+                _deleteRequester?.Tell(new Status.Failure(failure.Cause));
+                _deleteRequester = null;
                 break;
             case string cmd:
                 var sender = Sender;

--- a/src/Akka.Persistence.EventStore.Tests/Streams/EventStoreEventStreamFilterSpec.cs
+++ b/src/Akka.Persistence.EventStore.Tests/Streams/EventStoreEventStreamFilterSpec.cs
@@ -1,0 +1,30 @@
+using Akka.Persistence.EventStore.Streams;
+using Akka.Persistence.Query;
+using EventStore.Client;
+using Xunit;
+
+namespace Akka.Persistence.EventStore.Tests.Streams;
+
+public class EventStoreEventStreamFilterSpec
+{
+    [Fact]
+    public void FromOffsetExclusive_should_preserve_supported_offset_semantics()
+    {
+        var fromNull = EventStoreEventStreamFilter.FromOffsetExclusive("stream", null!);
+        var fromStart = EventStoreEventStreamFilter.FromOffsetExclusive("stream", Offset.NoOffset());
+        var fromSequence = EventStoreEventStreamFilter.FromOffsetExclusive("stream", Offset.Sequence(5));
+
+        Assert.Equal(StreamPosition.Start, fromNull.From);
+        Assert.Equal(StreamPosition.Start, fromStart.From);
+        Assert.Equal(StreamPosition.FromInt64(6), fromSequence.From);
+    }
+
+    [Fact]
+    public void FromOffsetExclusive_should_reject_unsupported_offset_types()
+    {
+        var unsupported = Offset.TimeBasedUuid(Guid.NewGuid());
+
+        Assert.Throws<ArgumentException>(
+            () => EventStoreEventStreamFilter.FromOffsetExclusive("stream", unsupported));
+    }
+}

--- a/src/Akka.Persistence.EventStore/Query/EventStoreReadJournal.cs
+++ b/src/Akka.Persistence.EventStore/Query/EventStoreReadJournal.cs
@@ -94,46 +94,61 @@ public class EventStoreReadJournal
             .Select(r => r.Data.PersistenceId);
     }
 
-    public Source<EventEnvelope, NotUsed> EventsByTag(string tag, Offset offset) => EventsFromStreamSource(
-        EventStoreEventStreamFilter.FromOffsetExclusive(
-            _writeSettings.GetTaggedStreamName(tag, _tenantSettings),
-            offset),
-        true,
+    public Source<EventEnvelope, NotUsed> EventsByTag(string tag, Offset offset) => EventsFromOffsetSource(
+        _writeSettings.GetTaggedStreamName(tag, _tenantSettings),
+        offset,
         true);
 
-    public Source<EventEnvelope, NotUsed> CurrentEventsByTag(string tag, Offset offset) => EventsFromStreamSource(
-        EventStoreEventStreamFilter.FromOffsetExclusive(
-            _writeSettings.GetTaggedStreamName(tag, _tenantSettings),
-            offset),
-        false,
+    public Source<EventEnvelope, NotUsed> CurrentEventsByTag(string tag, Offset offset) => EventsFromOffsetSource(
+        _writeSettings.GetTaggedStreamName(tag, _tenantSettings),
+        offset,
+        false);
+
+    public Source<EventEnvelope, NotUsed> AllEvents(Offset offset) => EventsFromOffsetSource(
+        _writeSettings.GetPersistedEventsStreamName(_tenantSettings),
+        offset,
         true);
 
-    public Source<EventEnvelope, NotUsed> AllEvents(Offset offset) => EventsFromStreamSource(
-        EventStoreEventStreamFilter.FromOffsetExclusive(
-            _writeSettings.GetPersistedEventsStreamName(_tenantSettings),
-            offset),
-        true,
-        true);
+    public Source<EventEnvelope, NotUsed> CurrentAllEvents(Offset offset) => EventsFromOffsetSource(
+        _writeSettings.GetPersistedEventsStreamName(_tenantSettings),
+        offset,
+        false);
 
-    public Source<EventEnvelope, NotUsed> CurrentAllEvents(Offset offset) => EventsFromStreamSource(
-        EventStoreEventStreamFilter.FromOffsetExclusive(
-            _writeSettings.GetPersistedEventsStreamName(_tenantSettings),
-            offset),
-        false,
-        true);
+    private Source<EventEnvelope, NotUsed> EventsFromOffsetSource(
+        string streamName,
+        Offset offset,
+        bool continuous)
+    {
+        if (offset is not FromEnd fromEnd)
+        {
+            return EventsFromStreamSource(
+                EventStoreEventStreamFilter.FromOffsetExclusive(streamName, offset),
+                continuous,
+                true);
+        }
+
+        // Resolve the relative offset independently for every materialization. Reading one extra link gives us the
+        // exclusive anchor immediately before the requested window, after which the normal ascending query can run.
+        var fromStart = EventStoreEventStreamFilter.FromStart(streamName);
+        var fromEndFilter = EventStoreEventStreamFilter.FromEnd(streamName);
+        return ReplaysFromStreamSource(fromEndFilter, continuous: false, resolveLinkTos: true)
+            // Match the forward query's event-adapter visibility before counting. Deleted/truncated target events
+            // leave unresolved projection links; deserialization removes those while retaining each surviving link's
+            // selected-stream revision in ReplayCompletion.Position.
+            .SelectMany(replay => AdaptEvents(replay.Data).Select(_ => replay))
+            .Skip(fromEnd.Count)
+            .Take(1)
+            .Select(replay => EventStoreEventStreamFilter.FromOffsetExclusive(
+                streamName,
+                new Sequence(replay.Position.ToInt64())))
+            .OrElse(Source.Single(fromStart))
+            .ConcatMany(filter => EventsFromStreamSource(filter, continuous, true));
+    }
 
     private Source<EventEnvelope, NotUsed> EventsFromStreamSource(
         EventStoreEventStreamFilter filter,
         bool continuous,
-        bool resolveLinkTos) => EventStoreSource
-        .FromStream(
-            _eventStoreClient,
-            filter,
-            resolveLinkTos,
-            continuous,
-            _settings.NoStreamTimeout)
-        .DeSerializeEventWith(_adapter)
-        .Filter(filter)
+        bool resolveLinkTos) => ReplaysFromStreamSource(filter, continuous, resolveLinkTos)
         .SelectMany(r =>
             AdaptEvents(r.Data)
                 .Select(_ => new { representation = r.Data, ordering = r.Position }))
@@ -146,6 +161,19 @@ public class EventStoreReadJournal
                     @event: r.representation.Payload,
                     timestamp: r.representation.Timestamp,
                     []));
+
+    private Source<ReplayCompletion<IPersistentRepresentation>, NotUsed> ReplaysFromStreamSource(
+        EventStoreEventStreamFilter filter,
+        bool continuous,
+        bool resolveLinkTos) => EventStoreSource
+        .FromStream(
+            _eventStoreClient,
+            filter,
+            resolveLinkTos,
+            continuous,
+            _settings.NoStreamTimeout)
+        .DeSerializeEventWith(_adapter)
+        .Filter(filter);
 
     private ImmutableList<IPersistentRepresentation> AdaptEvents(
         IPersistentRepresentation persistentRepresentation)

--- a/src/Akka.Persistence.EventStore/Streams/EventStoreEventStreamFilter.cs
+++ b/src/Akka.Persistence.EventStore/Streams/EventStoreEventStreamFilter.cs
@@ -105,11 +105,18 @@ public record EventStoreEventStreamFilter(
         long maxSequenceNumber = long.MaxValue,
         Direction direction = Direction.Forwards)
     {
+        var from = offset switch
+        {
+            null or NoOffset => StreamPosition.Start,
+            Sequence seq => StreamPosition.FromInt64(seq.Value + 1),
+            _ => throw new ArgumentException(
+                $"Offset type [{offset.GetType().Name}] is not supported.",
+                nameof(offset))
+        };
+
         return new EventStoreEventStreamFilter(
             streamName,
-            offset is Sequence seq
-                ? StreamPosition.FromInt64(seq.Value + 1)
-                : StreamPosition.Start,
+            from,
             minSequenceNumber,
             maxSequenceNumber,
             direction);


### PR DESCRIPTION
## Summary

- upgrade Akka.NET and Akka.Hosting dependencies to 1.5.70
- support Offset.FromEnd for current and live tag and all-events queries
- resolve the relative offset at materialization time by reading the selected projection stream backwards
- count only query-visible resolved and adapted events, preserving projection-stream revisions for the exclusive forward anchor
- cover deleted or truncated target streams so unresolved projection links do not reduce the requested window
- preserve null, NoOffset, and Sequence behavior and reject unsupported offsets

## Validation

- Release solution build and package
- focused FromEnd/dead-link/filter suite: 19 passed
- full suite: 163 passed, 3 existing skips, 0 failed
- audited package dependencies: stable Akka.NET 1.5.70, no beta references